### PR TITLE
Fix blog post filtering for enabled tags

### DIFF
--- a/blog/script.js
+++ b/blog/script.js
@@ -61,7 +61,7 @@ function toggleTag(tag) {
 function isPostVisible(post) {
   
   // A post is visible if it has at least one enabled tag
-  return post.tags.some(tag => enabledTags.has(tag)) && !post.tags.some(tag => disabledTags.has(tag))
+  return post.tags.some(tag => enabledTags.has(tag))
 }
 
 const reset = () => {


### PR DESCRIPTION
Update blog post visibility logic to show posts if they have at least one enabled tag.

The previous logic incorrectly hid posts if they contained *any* disabled tag, even if they also had enabled tags. This change ensures posts are visible as long as one tag is enabled.

---
<a href="https://cursor.com/background-agent?bcId=bc-b93df6df-95a8-4a47-9792-3e02995f9488">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-b93df6df-95a8-4a47-9792-3e02995f9488">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>